### PR TITLE
com.webos.surfacemanager.json: Add screen number

### DIFF
--- a/configs/layers/base/com.webos.surfacemanager.json
+++ b/configs/layers/base/com.webos.surfacemanager.json
@@ -1,3 +1,3 @@
 {
-    "compositorGeometry": "1920x1080+0+0r0"
+    "compositorGeometry": "1920x1080+0+0r0s1"
 }


### PR DESCRIPTION
To correctly reflect the required value so luna-surfacemanager is happy.

https://github.com/webosose/luna-surfacemanager/blob/168865d95dd6d3a30af2dac73e0d7236d6ac5030/modules/weboscompositor/weboscompositorconfig.cpp#L80

https://github.com/webOS-ports/luna-surfacemanager/blob/webOS-ports/webOS-OSE/base/startup/surface-manager.sh.in#L39

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>